### PR TITLE
feat(add-code): implement AddEditCode Screen with Code Preview, codes store with asyncStorage

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,7 @@ module.exports = {
           '@app': './src/app',
           '@domain': './src/domain',
           '@screen': './src/screen',
+          '@store': './src/store',
         },
       },
     ],

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1113,6 +1113,8 @@ PODS:
     - React-jsi (= 0.73.1)
     - React-logger (= 0.73.1)
     - React-perflogger (= 0.73.1)
+  - RNCAsyncStorage (1.21.0):
+    - React-Core
   - RNScreens (3.29.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1198,6 +1200,7 @@ DEPENDENCIES:
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - VisionCamera (from `../node_modules/react-native-vision-camera`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1316,6 +1319,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/utils"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   VisionCamera:
@@ -1384,6 +1389,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 93a4c84e46a85c3fc9678abd4f6923b785226ea7
   React-utils: debda2c206770ee2785bdebb7f16d8db9f18838a
   ReactCommon: ddb128564dcbfa0287d3d1a2d10f8c7457c971f6
+  RNCAsyncStorage: 618d03a5f52fbccb3d7010076bc54712844c18ef
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   VisionCamera: b236f548d6507923857dade542c7e0a148ed3492

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "Beaver",
       "version": "0.0.1",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.21.0",
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.17",
         "bwip-js": "^4.2.0",
@@ -19,6 +20,7 @@
         "react-native-paper": "^5.11.5",
         "react-native-safe-area-context": "^4.8.2",
         "react-native-screens": "^3.29.0",
+        "react-native-uuid": "^2.0.1",
         "react-native-vector-icons": "^10.0.3",
         "react-native-vision-camera": "^3.6.16",
         "react-zlib-js": "^1.0.5",
@@ -3061,6 +3063,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.21.0.tgz",
+      "integrity": "sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -8470,6 +8483,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -10892,6 +10913,17 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12414,6 +12446,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-uuid/-/react-native-uuid-2.0.1.tgz",
+      "integrity": "sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==",
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/react-native-vector-icons": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.21.0",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "bwip-js": "^4.2.0",
@@ -23,6 +24,7 @@
     "react-native-paper": "^5.11.5",
     "react-native-safe-area-context": "^4.8.2",
     "react-native-screens": "^3.29.0",
+    "react-native-uuid": "^2.0.1",
     "react-native-vector-icons": "^10.0.3",
     "react-native-vision-camera": "^3.6.16",
     "react-zlib-js": "^1.0.5",
@@ -43,12 +45,12 @@
     "babel-plugin-module-resolver": "^5.0.0",
     "eslint": "^8.56.0",
     "eslint-plugin-unused-imports": "^3.0.0",
+    "husky": "^8.0.0",
     "jest": "^29.6.3",
     "metro-react-native-babel-preset": "^0.77.0",
     "prettier": "2.8.8",
     "react-test-renderer": "18.2.0",
-    "typescript": "5.0.4",
-    "husky": "^8.0.0"
+    "typescript": "5.0.4"
   },
   "lint-staged": {
     "*.{ts,tsx}": "npm run lint:fix"

--- a/src/app/i18n/resources.ts
+++ b/src/app/i18n/resources.ts
@@ -4,14 +4,18 @@ import {GeneralKey, GeneralTranslationEN} from '@app/i18n/translations/general.t
 import {CameraKey, CameraTranslationEN} from '@app/i18n/translations/camera.ts';
 import {CodeKey, CodeTranslationEN} from '@app/i18n/translations/code.ts';
 import {NavigationKey, NavigationTranslationEN} from '@app/i18n/translations/navigation.ts';
+import {AddEditKey, AddEditKeyTranslationEN} from '@app/i18n/translations/add-edit.ts';
+import {ListKey, ListKeyTranslationEN} from '@app/i18n/translations/list.ts';
 
-export type TranslationKey = GeneralKey | CameraKey | CodeKey | NavigationKey;
+export type TranslationKey = GeneralKey | CameraKey | CodeKey | NavigationKey | AddEditKey | ListKey;
 
 export const TranslationEN: Record<TranslationKey, string> = {
   ...GeneralTranslationEN,
   ...CameraTranslationEN,
   ...CodeTranslationEN,
   ...NavigationTranslationEN,
+  ...AddEditKeyTranslationEN,
+  ...ListKeyTranslationEN,
 };
 
 export const i18nResources: Resource = {

--- a/src/app/i18n/translations/add-edit.ts
+++ b/src/app/i18n/translations/add-edit.ts
@@ -1,0 +1,14 @@
+export type AddEditKey =
+  | 'add-edit.code-type'
+  | 'add-edit.code-value'
+  | 'add-edit.code-title'
+  | 'add-edit.code-value.placeholder'
+  | 'add-edit.code-title.placeholder';
+
+export const AddEditKeyTranslationEN: Record<AddEditKey, string> = {
+  'add-edit.code-type': 'Type',
+  'add-edit.code-value': 'Value',
+  'add-edit.code-title': 'Title',
+  'add-edit.code-value.placeholder': 'Enter a code value...',
+  'add-edit.code-title.placeholder': 'Enter a code title...',
+};

--- a/src/app/i18n/translations/general.ts
+++ b/src/app/i18n/translations/general.ts
@@ -1,5 +1,8 @@
-export type GeneralKey = 'general.error';
+export type GeneralKey = 'general.error' | 'general.add' | 'general.edit' | 'general.cancel';
 
 export const GeneralTranslationEN: Record<GeneralKey, string> = {
   'general.error': 'Error',
+  'general.add': 'Add',
+  'general.edit': 'Edit',
+  'general.cancel': 'Cancel',
 };

--- a/src/app/i18n/translations/list.ts
+++ b/src/app/i18n/translations/list.ts
@@ -1,0 +1,5 @@
+export type ListKey = 'list.no-codes';
+
+export const ListKeyTranslationEN: Record<ListKey, string> = {
+  'list.no-codes': 'No codes added yet!',
+};

--- a/src/app/theme/darkTheme.ts
+++ b/src/app/theme/darkTheme.ts
@@ -12,5 +12,6 @@ export const darkTheme: MD3Theme = {
     error: ColorEnum.Red,
     onError: ColorEnum.Vine,
     outline: ColorEnum.Grey,
+    background: ColorEnum.Graphite,
   },
 };

--- a/src/app/theme/lightTheme.ts
+++ b/src/app/theme/lightTheme.ts
@@ -12,5 +12,6 @@ export const lightTheme: MD3Theme = {
     error: ColorEnum.Red,
     onError: ColorEnum.Coral,
     outline: ColorEnum.Grey,
+    background: ColorEnum.White,
   },
 };

--- a/src/domain/Code/components/CodeDrawer/CodeDrawer.tsx
+++ b/src/domain/Code/components/CodeDrawer/CodeDrawer.tsx
@@ -1,0 +1,55 @@
+import {toDataURL, CodeRenderOptions, BwipCodeTypes, DataURL} from 'bwip-js';
+import React, {useEffect, useMemo, useState} from 'react';
+import {Image} from 'react-native';
+
+type Props = {
+  type: BwipCodeTypes;
+  value: string | undefined;
+  codeContainerWidth: number | undefined;
+};
+
+export const CodeDrawer = ({type, value, codeContainerWidth}: Props) => {
+  const [codeImg, setCodeImg] = useState<DataURL>();
+
+  useEffect(() => {
+    const asyncEffect = async () => {
+      if (value && value.length > 0) {
+        const options: CodeRenderOptions = {bcid: type, text: value};
+        try {
+          const data = await toDataURL(options);
+          setCodeImg(data);
+        } catch (e) {
+          // `e` may be a string or Error object
+        }
+      }
+    };
+
+    // Generating code preview should be debounced
+    const timerId = setTimeout(() => {
+      void asyncEffect();
+    }, 300);
+
+    // Cleanup for debounce timer
+    return () => clearTimeout(timerId);
+  }, [type, value]);
+
+  const codeSize = useMemo<{height: number; width: number}>(() => {
+    if (codeImg && codeContainerWidth) {
+      const targetHeight = 140;
+      const maxFittedCodeWidth = codeContainerWidth - 20;
+
+      const aspectRatio = codeImg.width / codeImg.height;
+      const targetWidth = Math.min(maxFittedCodeWidth, targetHeight * aspectRatio);
+      return {width: targetWidth, height: targetHeight};
+    }
+
+    return {
+      width: 0,
+      height: 0,
+    };
+  }, [codeImg, codeContainerWidth]);
+
+  return codeImg ? (
+    <Image style={{height: codeSize.height, width: codeSize.width}} source={{uri: codeImg.uri}} />
+  ) : null;
+};

--- a/src/domain/Code/components/CodeListItem/CodeListItem.tsx
+++ b/src/domain/Code/components/CodeListItem/CodeListItem.tsx
@@ -7,13 +7,14 @@ type Props = {
   type: 'qr' | 'barcode';
   name: string;
   onPress: () => void;
+  onLongPress: () => void;
 };
 
-export const CodeListItem = ({type, name, onPress}: Props) => {
+export const CodeListItem = ({type, name, onPress, onLongPress}: Props) => {
   const {Wrapper, Box, Title} = useCodeListItemStyles();
 
   return (
-    <TouchableOpacity style={Wrapper} onPress={onPress}>
+    <TouchableOpacity style={Wrapper} onPress={onPress} onLongPress={onLongPress}>
       <View style={Box}>
         <Icon size={60} source={type === 'qr' ? 'qrcode' : 'barcode'} />
       </View>

--- a/src/screen/AddEditScreen/AddEditScreen.styles.ts
+++ b/src/screen/AddEditScreen/AddEditScreen.styles.ts
@@ -1,0 +1,45 @@
+import {ViewStyle} from 'react-native';
+import {useStylesheetWithTheme} from '@app/hook/useStylesheetWithTheme.ts';
+import {BorderRadius} from '@app/constans/BorderRadius.constans.ts';
+
+type ListScreenStyles = {
+  AddEditScreenWrapper: ViewStyle;
+  Box: ViewStyle;
+  CodeView: ViewStyle;
+  Spacer: ViewStyle;
+};
+
+export const useAddEditScreenStyles = () => {
+  return useStylesheetWithTheme<ListScreenStyles>(({colors}) => ({
+    AddEditScreenWrapper: {
+      minHeight: '100%',
+      backgroundColor: colors.surface,
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      position: 'relative',
+      flex: 1,
+      padding: 10,
+      paddingBottom: 50,
+    },
+    Box: {
+      marginVertical: 20,
+      width: '100%',
+      alignItems: 'stretch',
+      justifyContent: 'center',
+      gap: 8,
+    },
+    CodeView: {
+      minHeight: 150,
+      backgroundColor: colors.surfaceDisabled,
+      borderWidth: 2,
+      borderStyle: 'solid',
+      borderColor: colors.outline,
+      borderRadius: BorderRadius,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    Spacer: {
+      flex: 1,
+    },
+  }));
+};

--- a/src/screen/AddEditScreen/AddEditScreen.tsx
+++ b/src/screen/AddEditScreen/AddEditScreen.tsx
@@ -1,14 +1,41 @@
-import React, {useEffect} from 'react';
-import {Text, View} from 'react-native';
+import React, {useEffect, useMemo, useState} from 'react';
+import {View} from 'react-native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {StackParamList} from '@app/navigation/StackParamList.type.ts';
 import {useTranslation} from 'react-i18next';
+import {useAddEditScreenStyles} from '@screen/AddEditScreen/AddEditScreen.styles.ts';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {Button, TextInput} from 'react-native-paper';
+import {CodeDrawer} from '@domain/Code/components/CodeDrawer/CodeDrawer.tsx';
+import {useCodesStore} from '@store/codes.store';
 
 type Props = NativeStackScreenProps<StackParamList, 'AddEditCode'>;
 
 export const AddEditScreen = ({route, navigation}: Props) => {
+  const {AddEditScreenWrapper, Box, CodeView, Spacer} = useAddEditScreenStyles();
   const {t} = useTranslation();
   const {type, value, editMode} = route.params;
+
+  const [codeValue, setCodeValue] = useState<string | undefined>(value);
+  const [title, setTitle] = useState<string>('');
+  const [codeViewWidth, setCodeViewWidth] = useState<number>();
+
+  const addCode = useCodesStore(state => state.addCode);
+
+  const isDataProvided = useMemo(() => {
+    return !!(codeValue && codeValue?.length > 0 && title.length > 0);
+  }, [codeValue, title.length]);
+
+  const onCancelPress = () => {
+    navigation.navigate('List');
+  };
+
+  const onAddPress = () => {
+    if (isDataProvided) {
+      addCode({type, value: codeValue ?? '', title});
+      navigation.navigate('List');
+    }
+  };
 
   useEffect(() => {
     if (editMode) {
@@ -19,8 +46,37 @@ export const AddEditScreen = ({route, navigation}: Props) => {
   }, [editMode, navigation, t]);
 
   return (
-    <View>
-      <Text>{`Type: ${type} value: ${value ?? 'not set'}`}</Text>
-    </View>
+    <SafeAreaView style={AddEditScreenWrapper}>
+      <View style={Box}>
+        <View style={CodeView} onLayout={e => setCodeViewWidth(e.nativeEvent.layout.width)}>
+          <CodeDrawer type={type} value={codeValue} codeContainerWidth={codeViewWidth} />
+        </View>
+        <TextInput mode='outlined' label={t('add-edit.code-type')} value={`(${type}) ${t(`code.${type}`)}`} disabled />
+        <TextInput
+          mode='outlined'
+          label={t('add-edit.code-value')}
+          placeholder={t('add-edit.code-value.placeholder')}
+          value={codeValue}
+          onChangeText={valueText => setCodeValue(valueText)}
+        />
+        <TextInput
+          mode='outlined'
+          label={t('add-edit.code-title')}
+          placeholder={t('add-edit.code-title.placeholder')}
+          maxLength={45}
+          value={title}
+          onChangeText={titleText => setTitle(titleText)}
+        />
+      </View>
+      <View style={Spacer} />
+      <View style={Box}>
+        <Button mode='contained' disabled={!isDataProvided} onPress={onAddPress}>
+          {editMode ? t('general.edit') : t('general.add')}
+        </Button>
+        <Button mode='text' onPress={onCancelPress}>
+          {t('general.cancel')}
+        </Button>
+      </View>
+    </SafeAreaView>
   );
 };

--- a/src/screen/ListScreen/ListScreen.styles.ts
+++ b/src/screen/ListScreen/ListScreen.styles.ts
@@ -1,4 +1,4 @@
-import {ViewStyle} from 'react-native';
+import {TextStyle, ViewStyle} from 'react-native';
 import {useStylesheetWithTheme} from '@app/hook/useStylesheetWithTheme.ts';
 
 type ListScreenStyles = {
@@ -7,6 +7,7 @@ type ListScreenStyles = {
   Backdrop: ViewStyle;
   ButtonsBox: ViewStyle;
   SubButtonsBox: ViewStyle;
+  NoCodes: TextStyle;
 };
 
 export const useListScreenStyles = () => {
@@ -45,6 +46,11 @@ export const useListScreenStyles = () => {
     SubButtonsBox: {
       justifyContent: 'center',
       alignItems: 'center',
+    },
+    NoCodes: {
+      marginVertical: 50,
+      width: '100%',
+      textAlign: 'center',
     },
   }));
 };

--- a/src/screen/ListScreen/ListScreen.tsx
+++ b/src/screen/ListScreen/ListScreen.tsx
@@ -7,14 +7,19 @@ import {ScrollView, TouchableOpacity, View, ViewStyle} from 'react-native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {StackParamList} from '@app/navigation/StackParamList.type.ts';
 import {useGrowAnimation} from '@app/hook/useGrowAnimation.ts';
+import {useCodesStore} from '@store/codes.store.ts';
+import {useTranslation} from 'react-i18next';
 
 type Props = NativeStackScreenProps<StackParamList, 'List'>;
 
 export const ListScreen = ({navigation}: Props) => {
-  const {ListScreenWrapper, List, ButtonsBox, SubButtonsBox, Backdrop} = useListScreenStyles();
+  const {t} = useTranslation();
+  const {ListScreenWrapper, List, ButtonsBox, SubButtonsBox, Backdrop, NoCodes} = useListScreenStyles();
   const {colors} = useTheme();
   const [menuOpened, setMenuOpened] = useState(false);
   const growAnimation = useGrowAnimation({opened: menuOpened});
+
+  const [codes, removeCode] = useCodesStore(state => [state.codes, state.removeCode]);
 
   const iconButtonsStyle = useMemo<ViewStyle>(
     () => ({
@@ -31,6 +36,10 @@ export const ListScreen = ({navigation}: Props) => {
     setMenuOpened(false);
   };
 
+  const onLongCodePress = (id: string) => {
+    removeCode(id);
+  };
+
   const onNewCodePress = () => {
     navigation.navigate('ChooseType');
     setMenuOpened(false);
@@ -45,11 +54,20 @@ export const ListScreen = ({navigation}: Props) => {
     <SafeAreaView style={ListScreenWrapper}>
       <Text variant='headlineLarge'>Beaver</Text>
       <ScrollView contentContainerStyle={List}>
-        <CodeListItem type='qr' name='Code #1' onPress={onCodePress} />
-        <CodeListItem type='qr' name='Code #2' onPress={onCodePress} />
-        <CodeListItem type='barcode' name='Code #3' onPress={onCodePress} />
-        <CodeListItem type='qr' name='Code #4' onPress={onCodePress} />
-        <CodeListItem type='qr' name='Code #5' onPress={onCodePress} />
+        {codes.map(code => (
+          <CodeListItem
+            key={code.id}
+            type='qr'
+            name={code.title}
+            onPress={onCodePress}
+            onLongPress={() => onLongCodePress(code.id)}
+          />
+        ))}
+        {codes.length === 0 && (
+          <Text variant='titleLarge' style={NoCodes}>
+            {t('list.no-codes')}
+          </Text>
+        )}
       </ScrollView>
       {menuOpened && <TouchableOpacity style={Backdrop} onPress={() => setMenuOpened(false)} />}
       <View style={ButtonsBox}>

--- a/src/store/codes.store.ts
+++ b/src/store/codes.store.ts
@@ -1,22 +1,35 @@
 import {Code, CodeID} from '@domain/Code/model/Code.ts';
-import {createStore} from 'zustand';
+import {create} from 'zustand';
+import {createJSONStorage, persist} from 'zustand/middleware';
+import uuid from 'react-native-uuid';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 type CodesStore = {
   codes: Code[];
-  addCode: (code: Code) => void;
+  addCode: (codeData: Omit<Code, 'id'>) => void;
   removeCode: (id: CodeID) => void;
 };
 
-export const codesStore = createStore<CodesStore>()(set => ({
-  codes: [],
-  addCode: code => {
-    set(({codes: prevCodes}) => ({codes: [...prevCodes, code]}));
-  },
-  removeCode: id => {
-    set(({codes: prevCodes}) => {
-      return {
-        codes: prevCodes.filter(c => c.id !== id),
-      };
-    });
-  },
-}));
+export const useCodesStore = create<CodesStore>()(
+  persist(
+    set => ({
+      codes: [],
+      addCode: codeData => {
+        const id = uuid.v4().toString();
+        set(({codes: prevCodes}) => ({codes: [...prevCodes, {id, ...codeData}]}));
+        return id;
+      },
+      removeCode: id => {
+        set(({codes: prevCodes}) => {
+          return {
+            codes: prevCodes.filter(c => c.id !== id),
+          };
+        });
+      },
+    }),
+    {
+      name: 'codes-store',
+      storage: createJSONStorage(() => AsyncStorage),
+    },
+  ),
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
       ],
       "@screen/*": [
         "src/screen/*"
+      ],
+      "@store/*": [
+        "src/store/*"
       ]
     }
   },


### PR DESCRIPTION
### Changes:

 - Implement **AddEditCode** Screen with **CodeDrawer** component for preview, 
 - Implement zustand's `codesStore` with saving data in `asyncStorage`, 
 - Add codes from store in **List** Screen, 
 - Add new translations.